### PR TITLE
Update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ class Post extends Model implements TypesenseSearch
 
     public function getCollectionSchema(): array {
       return [
-        'name' => $this->getTable(),
+        'name' => $this->searchableAs(),
         'fields' => [
           [
             'name' => 'title',

--- a/composer.json
+++ b/composer.json
@@ -35,13 +35,7 @@
   },
   "require": {
     "php": ">=7.4",
-    "laravel/scout": "7.*|^8.0",
-    "illuminate/bus": "^8.0",
-    "illuminate/contracts": "^8.0",
-    "illuminate/database": "^8.0",
-    "illuminate/pagination": "^8.0",
-    "illuminate/queue": "^8.0",
-    "illuminate/support": "^8.0",
+    "laravel/scout": "^8.0",
     "typesense/typesense-php": "^4.0"
   },
   "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -34,15 +34,15 @@
     }
   },
   "require": {
-    "php": "~7.2",
+    "php": ">=7.4",
     "laravel/scout": "7.*|^8.0",
-    "illuminate/bus": "^6.0|^7.0|^8.0",
-    "illuminate/contracts": "^6.0|^7.0|^8.0",
-    "illuminate/database": "^6.0|^7.0|^8.0",
-    "illuminate/pagination": "^6.0|^7.0|^8.0",
-    "illuminate/queue": "^6.0|^7.0|^8.0",
-    "illuminate/support": "^6.0|^7.0|^8.0",
-    "typesense/typesense-php": "^2.0"
+    "illuminate/bus": "^8.0",
+    "illuminate/contracts": "^8.0",
+    "illuminate/database": "^8.0",
+    "illuminate/pagination": "^8.0",
+    "illuminate/queue": "^8.0",
+    "illuminate/support": "^8.0",
+    "typesense/typesense-php": "^4.0"
   },
   "suggest": {
     "typesense/typesense-php": "Required to use the Typesense php client."

--- a/composer.json
+++ b/composer.json
@@ -36,16 +36,16 @@
   "require": {
     "php": "~7.2",
     "laravel/scout": "7.*|^8.0",
-    "illuminate/bus": "^6.0|^7.0",
-    "illuminate/contracts": "^6.0|^7.0",
-    "illuminate/database": "^6.0|^7.0",
-    "illuminate/pagination": "^6.0|^7.0",
-    "illuminate/queue": "^6.0|^7.0",
-    "illuminate/support": "^6.0|^7.0",
-    "devloopsnet/typesens-php": "^2.0"
+    "illuminate/bus": "^6.0|^7.0|^8.0",
+    "illuminate/contracts": "^6.0|^7.0|^8.0",
+    "illuminate/database": "^6.0|^7.0|^8.0",
+    "illuminate/pagination": "^6.0|^7.0|^8.0",
+    "illuminate/queue": "^6.0|^7.0|^8.0",
+    "illuminate/support": "^6.0|^7.0|^8.0",
+    "typesense/typesense-php": "^2.0"
   },
   "suggest": {
-    "devloopsnet/typesens-php": "Required to use the Typesense php client."
+    "typesense/typesense-php": "Required to use the Typesense php client."
   },
   "require-dev": {
     "phpunit/phpunit": "^8.0|^9.0",

--- a/src/Engines/TypesenseSearchEngine.php
+++ b/src/Engines/TypesenseSearchEngine.php
@@ -90,14 +90,16 @@ class TypesenseSearchEngine extends Engine
     public function paginate(Builder $builder, $perPage, $page)
     {
         return $this->performSearch(
-          $builder,
-          [
-            'q'        => $builder->query,
-            'query_by' => implode(',', $builder->model->typesenseQueryBy()),
-            'filter_by' => $this->filters($builder),
-            'per_page' => $perPage,
-            'page'     => $page,
-          ]
+            $builder,
+            array_filter(
+                [
+                    'q'        => $builder->query,
+                    'query_by' => implode(',', $builder->model->typesenseQueryBy()),
+                    'filter_by' => $this->filters($builder),
+                    'per_page' => $perPage,
+                    'page'     => $page,
+                ]
+            )
         );
     }
 

--- a/src/Engines/TypesenseSearchEngine.php
+++ b/src/Engines/TypesenseSearchEngine.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Devloops\LaravelTypesense\Typesense;
 use GuzzleHttp\Exception\GuzzleException;
-use Devloops\Typesence\Exceptions\TypesenseClientError;
+use Typesense\Exceptions\TypesenseClientError;
 
 /**
  * Class TypesenseSearchEngine
@@ -106,7 +106,7 @@ class TypesenseSearchEngine extends Engine
      * @param   array                   $options
      *
      * @return array|mixed
-     * @throws \Devloops\Typesence\Exceptions\TypesenseClientError
+     * @throws \Typesense\Exceptions\TypesenseClientError
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
     protected function performSearch(Builder $builder, array $options = [])

--- a/src/Engines/TypesenseSearchEngine.php
+++ b/src/Engines/TypesenseSearchEngine.php
@@ -129,9 +129,9 @@ class TypesenseSearchEngine extends Engine
     /**
      * @param   \Laravel\Scout\Builder  $builder
      *
-     * @return array
+     * @return string
      */
-    protected function filters(Builder $builder): array
+    protected function filters(Builder $builder): string
     {
         return collect($builder->wheres)->map(
           static function ($value, $key) {

--- a/src/Engines/TypesenseSearchEngine.php
+++ b/src/Engines/TypesenseSearchEngine.php
@@ -95,8 +95,8 @@ class TypesenseSearchEngine extends Engine
             'q'        => $builder->query,
             'query_by' => implode(',', $builder->model->typesenseQueryBy()),
             'filter_by' => $this->filters($builder),
-            'per_page' => $builder->limit,
-            'page'     => 1,
+            'per_page' => $perPage,
+            'page'     => $page,
           ]
         );
     }

--- a/src/Engines/TypesenseSearchEngine.php
+++ b/src/Engines/TypesenseSearchEngine.php
@@ -76,7 +76,7 @@ class TypesenseSearchEngine extends Engine
             [
               'q'        => $builder->query,
               'query_by' => implode(',', $builder->model->typesenseQueryBy()),
-              'fiter_by' => $this->filters($builder),
+              'filter_by' => $this->filters($builder),
               'per_page' => $builder->limit,
               'page'     => 1,
             ]
@@ -94,7 +94,7 @@ class TypesenseSearchEngine extends Engine
           [
             'q'        => $builder->query,
             'query_by' => implode(',', $builder->model->typesenseQueryBy()),
-            'fiter_by' => $this->filters($builder),
+            'filter_by' => $this->filters($builder),
             'per_page' => $builder->limit,
             'page'     => 1,
           ]
@@ -188,11 +188,7 @@ class TypesenseSearchEngine extends Engine
     public function flush($model): void
     {
         $collection = $this->typesense->getCollectionIndex($model);
-        try {
-            $collection->delete();
-        } catch (TypesenseClientError $e) {
-        } catch (GuzzleException $e) {
-        }
+        $collection->delete();
     }
 
 }

--- a/src/Engines/TypesenseSearchEngine.php
+++ b/src/Engines/TypesenseSearchEngine.php
@@ -137,7 +137,7 @@ class TypesenseSearchEngine extends Engine
           static function ($value, $key) {
               return $key . ':=' . $value;
           }
-        )->values()->all();
+        )->values()->implode(' && ');
     }
 
     /**

--- a/src/Typesense.php
+++ b/src/Typesense.php
@@ -1,15 +1,13 @@
 <?php
 
-
 namespace Devloops\LaravelTypesense;
 
-
-use Devloops\Typesence\Client;
-use Devloops\Typesence\Document;
-use Devloops\Typesence\Collection;
+use Typesense\Client;
+use Typesense\Document;
+use Typesense\Collection;
 use GuzzleHttp\Exception\GuzzleException;
-use Devloops\Typesence\Exceptions\ObjectNotFound;
-use Devloops\Typesence\Exceptions\TypesenseClientError;
+use Typesense\Exceptions\ObjectNotFound;
+use Typesense\Exceptions\TypesenseClientError;
 
 /**
  * Class Typesense
@@ -22,14 +20,14 @@ class Typesense
 {
 
     /**
-     * @var \Devloops\Typesence\Client
+     * @var \Typesense\Client
      */
     private $client;
 
     /**
      * Typesense constructor.
      *
-     * @param   \Devloops\Typesence\Client  $client
+     * @param   \Typesense\Client  $client
      */
     public function __construct(Client $client)
     {
@@ -37,7 +35,7 @@ class Typesense
     }
 
     /**
-     * @return \Devloops\Typesence\Client
+     * @return \Typesense\Client
      */
     public function getClient(): Client
     {
@@ -47,8 +45,8 @@ class Typesense
     /**
      * @param   \Illuminate\Database\Eloquent\Model|\Devloops\LaravelTypesense\Interfaces\TypesenseSearch  $model
      *
-     * @return \Devloops\Typesence\Collection
-     * @throws \Devloops\Typesence\Exceptions\TypesenseClientError
+     * @return \Typesense\Collection
+     * @throws \Typesense\Exceptions\TypesenseClientError
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
     private function createCollectionFromModel($model): Collection
@@ -72,8 +70,8 @@ class Typesense
     /**
      * @param   \Illuminate\Database\Eloquent\Model  $model
      *
-     * @return \Devloops\Typesence\Collection
-     * @throws \Devloops\Typesence\Exceptions\TypesenseClientError
+     * @return \Typesense\Collection
+     * @throws \Typesense\Exceptions\TypesenseClientError
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
     public function getCollectionIndex($model): Collection
@@ -82,10 +80,10 @@ class Typesense
     }
 
     /**
-     * @param   \Devloops\Typesence\Collection  $collectionIndex
+     * @param   \Typesense\Collection  $collectionIndex
      * @param                                   $array
      *
-     * @throws \Devloops\Typesence\Exceptions\TypesenseClientError
+     * @throws \Typesense\Exceptions\TypesenseClientError
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
     public function upsertDocument(Collection $collectionIndex, $array): void
@@ -101,14 +99,14 @@ class Typesense
             $collectionIndex->getDocuments()->create($array);
         } catch (ObjectNotFound $e) {
             $collectionIndex->getDocuments()->create($array);
-        } catch (TypesenseClientError $e) {
-        } catch (GuzzleException $e) {
         }
     }
 
     /**
-     * @param   \Devloops\Typesence\Collection  $collectionIndex
-     * @param                                   $modelId
+     * @param \Typesense\Collection $collectionIndex
+     * @param int                   $modelId
+     * @throws GuzzleException
+     * @throws TypesenseClientError
      */
     public function deleteDocument(Collection $collectionIndex, $modelId): void
     {
@@ -116,11 +114,7 @@ class Typesense
          * @var $document Document
          */
         $document = $collectionIndex->getDocuments()[(string)$modelId];
-        try {
-            $document->delete();
-        } catch (TypesenseClientError $e) {
-        } catch (GuzzleException $e) {
-        }
+        $document->delete();
     }
 
 }

--- a/src/Typesense.php
+++ b/src/Typesense.php
@@ -49,9 +49,9 @@ class Typesense
      * @throws \Typesense\Exceptions\TypesenseClientError
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    private function createCollectionFromModel($model): Collection
+    private function getOrCreateCollectionFromModel($model): Collection
     {
-        $index = $this->client->getCollections()->{$model->getTable()};
+        $index = $this->client->getCollections()->{$model->searchableAs()};
         try {
             $index->retrieve();
 
@@ -62,8 +62,6 @@ class Typesense
             );
 
             return $this->client->getCollections()->{$model->getTable()};
-        } catch (TypesenseClientError $exception) {
-            throw $exception;
         }
     }
 
@@ -76,7 +74,7 @@ class Typesense
      */
     public function getCollectionIndex($model): Collection
     {
-        return $this->createCollectionFromModel($model);
+        return $this->getOrCreateCollectionFromModel($model);
     }
 
     /**

--- a/src/TypesenseServiceProvider.php
+++ b/src/TypesenseServiceProvider.php
@@ -2,7 +2,7 @@
 
 namespace Devloops\LaravelTypesense;
 
-use Devloops\Typesence\Client;
+use Typesense\Client;
 use Laravel\Scout\EngineManager;
 use Illuminate\Support\ServiceProvider;
 use Devloops\LaravelTypesense\Engines\TypesenseSearchEngine;


### PR DESCRIPTION
Allow Laravel 8 and change to use the new namespace of the Typesense PHP library.

Also removed the catching and silently ignoring of exceptions, so this also closes #3.

I've also made a change to use the model's `searchableAs` method as defined by Scout, to define what the name of the index should be.