### PR TITLE
We should use searchableAs for the collection/index name

### DIFF
--- a/src/Typesense.php
+++ b/src/Typesense.php
@@ -61,7 +61,7 @@ class Typesense
               $model->getCollectionSchema()
             );
 
-            return $this->client->getCollections()->{$model->getTable()};
+            return $this->client->getCollections()->{$model->searchableAs()};
         }
     }
 


### PR DESCRIPTION
Sorry, missed this one in the last PR where I updated it from `getTable` to `searchableAs`!