### PR TITLE
Add builder as a parameter for search callback

### DIFF
--- a/src/Engines/TypesenseSearchEngine.php
+++ b/src/Engines/TypesenseSearchEngine.php
@@ -223,7 +223,7 @@ class TypesenseSearchEngine extends Engine
         $documents = $this->typesense->getCollectionIndex($builder->model)
                                      ->getDocuments();
         if ($builder->callback) {
-            return call_user_func($builder->callback, $documents, $builder->query, $options);
+            return call_user_func($builder->callback, $builder, $documents, $builder->query, $options);
         }
 
         return $documents->search($options);


### PR DESCRIPTION
If a callback is used when searching (ex: Model::search('term', function (...args) { closure })) there is an error, "Too few arguments to function {closure}(), 3 passed and exactly 4 expected".

$builder->callback is the closure itself. Next it is expecting the builder but is receiving $documents.